### PR TITLE
Added support for Binance Smart Chain API url

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,14 @@ Supported:
 $client = new \Etherscan\Client('Y3U3GMFC8P545CFWRU4TET8MY1K79YDZ3V', EtherscanAPIConf::TESTNET_RINKEBY);
 $client->api('account')->balance('0x43406D1baAE11a950DE734DAE4079A3C9Eb48DAf');
 ```
+
+
+## For Binance Smart Chain (BSC) usage
+
+In order to query the BSC you need a different API. You can obtain it here: https://bscscan.com/apis.
+Here the call:
+
+```php
+$bsc_client = new \Etherscan\Client('Y3U3GMFC8P545CFWRU4TET8MY1K79YDZ3V', EtherscanAPIConf::NET_BSC);
+$bsc_client      ->api('account')->balance('0x43406D1baAE11a950DE734DAE4079A3C9Eb48DAf');
+```

--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ Here the call:
 
 ```php
 $bsc_client = new \Etherscan\Client('Y3U3GMFC8P545CFWRU4TET8MY1K79YDZ3V', EtherscanAPIConf::NET_BSC);
-$bsc_client      ->api('account')->balance('0x43406D1baAE11a950DE734DAE4079A3C9Eb48DAf');
+$bsc_client->api('account')->balance('0x43406D1baAE11a950DE734DAE4079A3C9Eb48DAf');
 ```

--- a/lib/Etherscan/APIConf.php
+++ b/lib/Etherscan/APIConf.php
@@ -50,3 +50,6 @@ class APIConf
 
         return "https://{$net}.etherscan.io/api";
     }
+
+}
+

--- a/lib/Etherscan/APIConf.php
+++ b/lib/Etherscan/APIConf.php
@@ -17,7 +17,7 @@ class APIConf
     const TESTNET_KOVAN = "api-kovan";
     const TESTNET_RINKEBY = "api-rinkeby";
 
-    const NET_BSCSCAN = 'api-bscscan'; 
+    const NET_BSC = 'api-bscscan'; 
 
     const TAG_LATEST = "latest";
 
@@ -34,7 +34,7 @@ class APIConf
         if (is_null($net)) {
             return self::API_URL;
         }
-        else if($net === self::NET_BSCSCAN) {
+        else if($net === self::NET_BSC) {
             return self::API_URL_BSCSCAN;
         }
 

--- a/lib/Etherscan/APIConf.php
+++ b/lib/Etherscan/APIConf.php
@@ -11,9 +11,13 @@ class APIConf
 {
     const API_URL = "https://api.etherscan.io/api";
 
+    const API_URL_BSCSCAN = 'https://api.bscscan.com/api';
+
     const TESTNET_ROPSTEN = "api-ropsten";
     const TESTNET_KOVAN = "api-kovan";
     const TESTNET_RINKEBY = "api-rinkeby";
+
+    const NET_BSCSCAN = 'api-bscscan'; 
 
     const TAG_LATEST = "latest";
 
@@ -29,6 +33,9 @@ class APIConf
     public static function getAPIUrl($net = null) {
         if (is_null($net)) {
             return self::API_URL;
+        }
+        else if($net === self::NET_BSCSCAN) {
+            return self::API_URL_BSCSCAN;
         }
 
         return "https://{$net}.etherscan.io/api";


### PR DESCRIPTION
As far as my - potentially incomplete - information goes, bscscan.com works exactly like etherscan.io, being a fork of it. 
To allow calls to bscscan.com you can then simply configure the URL, methods and actions should be the same. 
Therefore it is possible to make calls with : 

```
$client = new \Etherscan\Client($YOUR_APIKEY,  \Etherscan\APIConf::NET_BSC );
$res = $client->api('account')->balance($YOUR_WALLET_TOKEN);
```