### PR TITLE
Added getTransactionReceipt function

### DIFF
--- a/lib/Etherscan/Api/Proxy.php
+++ b/lib/Etherscan/Api/Proxy.php
@@ -100,6 +100,23 @@ class Proxy extends AbstractApi
     }
 
     /**
+     * Returns the receipt of a transaction by transaction hash
+     *
+     * @param string $transactionHash
+     * 
+     * @return array
+     * @throws ErrorException
+     */
+    public function getTransactionReceipt($transactionHash)
+    {
+        return $this->request->exec([
+            'module' => "proxy",
+            'action' => "eth_getTransactionReceipt",
+            'txhash' => $transactionHash
+        ]);
+    }
+
+    /**
      * Returns the number of most recent block
      *
      * @return array


### PR DESCRIPTION
Hi @maslakoff ,
Just submit a new PR to this project because the function submitted last week return incomplete results

Reason of the PR :
To get an ERC20 transfer's information, need the transaction receipt, since transfer information is recorded in a transfer event log, using eth_getTransactionReceipt.