### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,65 +1,97 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.8] - 2022-03-22
+
+### Changed
+
+-   Account: `tokenERC721TransferListByAddress` method was changed to support `startblock` and `endblock` params
 
 ## [1.3.7] - 2021-11-25
+
 ### Added
-- Proxy: getTransactionReceipt
+
+-   Proxy: getTransactionReceipt
 
 ## [1.3.6] - 2021-11-15
+
 ### Added
-- Proxy: getTransactionByHash
+
+-   Proxy: getTransactionByHash
 
 ## [1.3.5] - 2021-11-03
+
 ### Added
-- Stats actions
+
+-   Stats actions
 
 ## [1.3.4] - 2021-11-03
+
 ### Added
-- Gas Tracker actions
+
+-   Gas Tracker actions
 
 ## [1.3.3] - 2021-11-03
+
 ### Added
-- token actions
+
+-   token actions
 
 ## [1.3.2] - 2021-10-14
+
 ### Changed
-- update documentation links
-- update LICENSE
+
+-   update documentation links
+-   update LICENSE
 
 ## [1.3.0] - 2021-10-12
+
 ### Changed
-- update Blocks API
+
+-   update Blocks API
 
 ## [1.2.0] - 2021-10-05
+
 ### Changed
-- update Contracts API
+
+-   update Contracts API
 
 ## [1.1.0] - 2021-09-28
+
 ### Added
-- CHANGELOG.md
-- missed tag for blocks
-- missed account API actions
+
+-   CHANGELOG.md
+-   missed tag for blocks
+-   missed account API actions
 
 ### Changed
-- Rename `tokenTransactionListByAddress` to `tokenERC20TransferListByAddress`
+
+-   Rename `tokenTransactionListByAddress` to `tokenERC20TransferListByAddress`
 
 ### Deprecated
-- account tokenBalance method marked as deprecated and will be moved soon
+
+-   account tokenBalance method marked as deprecated and will be moved soon
 
 ## [1.0.1] - 2021-09-27
+
 ### Added
-- Merge pull request [#6](https://github.com/maslakoff/php-etherscan-api/pull/6):
-    - add transactionListByAddress action
-    - add tokenTransactionListByAddress action
+
+-   Merge pull request [#6](https://github.com/maslakoff/php-etherscan-api/pull/6):
+    -   add transactionListByAddress action
+    -   add tokenTransactionListByAddress action
 
 ## [1.0.0] - 2021-09-27
+
 ### Added
-- Goerli test network
+
+-   Goerli test network
 
 ## [0.9.0] - 2018-03-24
+
 ### Added
-- initial version
+
+-   initial version

--- a/lib/Etherscan/Api/Account.php
+++ b/lib/Etherscan/Api/Account.php
@@ -190,13 +190,15 @@ class Account extends AbstractApi
      * @param string $sort 'asc' or 'desc'
      * @param int $page Page number
      * @param int $offset Offset
+     * @param int $startBlock Starting blockNo to retrieve results
+     * @param int $endBlock Ending blockNo to retrieve results
      *
      * @throws InvalidArgumentException if missed address
      *
      * @return array
      * @throws ErrorException
      */
-    public function tokenERC721TransferListByAddress($address = null, $contractAddress = null, $sort = "asc", $page = null, $offset = null)
+    public function tokenERC721TransferListByAddress($address = null, $contractAddress = null, $sort = "asc", $page = null, $offset = null, $startBlock = 0, $endBlock = 99999999)
     {
         if (is_null($address) && is_null($contractAddress)) {
             throw new InvalidArgumentException('Please specify at least one address');
@@ -205,6 +207,8 @@ class Account extends AbstractApi
         $params = [
             'module' => "account",
             'action' => "tokennfttx",
+            'startblock' => $startBlock,
+            'endblock' => $endBlock,
             'sort' => $sort
         ];
 


### PR DESCRIPTION
Account: `tokenERC721TransferListByAddress` method was changed to support `startblock` and `endblock` params

Close #10 